### PR TITLE
Replace \times macro with "by".

### DIFF
--- a/man/generate_mixture.Rd
+++ b/man/generate_mixture.Rd
@@ -14,7 +14,7 @@ generate_mixture(n, p, k, beta = matrix(runif(k * p, -2, 2), nrow = k),
 
 \item{k}{Number of classes}
 
-\item{beta}{A $k \times p$ matrix with the true regression coefficients for each mixture component}
+\item{beta}{A $k$ by $p$ matrix with the true regression coefficients for each mixture component}
 
 \item{ak}{A vector of length k summing to 1 for the mixture probabilties}
 }

--- a/man/ll_compute.Rd
+++ b/man/ll_compute.Rd
@@ -11,7 +11,7 @@ ll_compute(y, X, beta, ak = 1, wk = 1)
 
 \item{X}{The feature vector of the current observation}
 
-\item{beta}{A $k \times p$ matrix with the true regression coefficients for each mixture component}
+\item{beta}{A $k$ by $p$ matrix with the true regression coefficients for each mixture component}
 
 \item{ak}{A vector of length k summing to 1 for the mixture probabilties}
 

--- a/man/online_log_mixture.Rd
+++ b/man/online_log_mixture.Rd
@@ -12,7 +12,7 @@ online_log_mixture(p, k, beta = matrix(runif(k * p, -1, 1), nrow = k),
 
 \item{k}{Number of mixture components}
 
-\item{beta}{A $k \times p$ matrix with the true regression coefficients for each mixture component}
+\item{beta}{A $k$ by $p$ matrix with the true regression coefficients for each mixture component}
 
 \item{ak}{A vector of length $k$ summing to 1 for the mixture probabilties}
 


### PR DESCRIPTION
\times macro is causing a compilation error; the \times macro was replaced with "by" to avoid the compilation error.